### PR TITLE
More comprehensive export list from the main module

### DIFF
--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -43,6 +43,7 @@ module Servant.API.Routes
   , pattern Routes
   , Route
   , defRoute
+  , showRoute
 
     -- * Automatic generation of routes for Servant API types
 
@@ -51,6 +52,32 @@ module Servant.API.Routes
     -- defining their own combinators.
   , HasRoutes (..)
   , printRoutes
+
+    -- * Types and helper functions
+
+    -- ** URL paths
+  , Path
+  , rootPath
+  , prependPathPart
+  , renderPath
+
+    -- ** Request/response bodies
+  , Body
+  , noBody
+  , oneType
+  , allOf
+  , oneOf
+
+    -- ** Request/response headers
+  , HeaderRep
+  , mkHeaderRep
+
+    -- ** Query parameters
+  , Param
+  , singleParam
+  , arrayElemParam
+  , flagParam
+  , renderParam
   )
 where
 


### PR DESCRIPTION
Export most of the types and functions from `Servant.API.Routes.*`, so the user only has to import the main module for most cases.