### PR TITLE
Pretty versions of `printRoutes`

### DIFF
--- a/servant-routes.cabal
+++ b/servant-routes.cabal
@@ -41,6 +41,7 @@ common deps
     , containers >= 0.6 && < 0.8
     , microlens >= 0.4.9 && < 0.5
     , microlens-th >= 0.4.3 && < 0.5
+    , aeson-pretty >= 0.8.8 && < 0.9
 
 common extensions
   default-extensions:

--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -51,10 +51,13 @@ module Servant.API.Routes
     -- defining their own combinators.
   , HasRoutes (..)
   , printRoutes
+  , printRoutesJSON
+  , printRoutesJSONPretty
   )
 where
 
 import Data.Aeson
+import Data.Aeson.Encode.Pretty
 import qualified Data.Aeson.Key as AK (fromText)
 import qualified Data.Aeson.Types as A (Pair)
 import Data.Bifunctor (bimap)
@@ -62,6 +65,8 @@ import Data.Foldable (foldl', traverse_)
 import qualified Data.Map as Map
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
 import Data.Typeable
 import GHC.TypeLits (KnownSymbol, Symbol)
 import Lens.Micro
@@ -230,6 +235,28 @@ printRoutes :: forall api. HasRoutes api => IO ()
 printRoutes = traverse_ printRoute $ getRoutes @api
   where
     printRoute = T.putStrLn . showRoute
+
+{- | Same as 'printRoutes`, but encode the t'Routes' as JSON before printing to stdout.
+For an even prettier version, see 'printRoutesJSONPretty'.
+-}
+printRoutesJSON :: forall api. HasRoutes api => IO ()
+printRoutesJSON =
+  T.putStrLn
+    . TL.toStrict
+    . TLE.decodeUtf8
+    . encode
+    . Routes
+    $ getRoutes @api
+
+-- | Pretty-encode the t'Routes' as JSON before printing to stdout.
+printRoutesJSONPretty :: forall api. HasRoutes api => IO ()
+printRoutesJSONPretty =
+  T.putStrLn
+    . TL.toStrict
+    . TLE.decodeUtf8
+    . encodePretty
+    . Routes
+    $ getRoutes @api
 
 instance HasRoutes EmptyAPI where
   getRoutes = mempty


### PR DESCRIPTION
`printRoutesJSON` prints routes to stdout in full JSON detail;
`printRoutesJSONPretty` uses `aeson-pretty` to format the JSON nicely before doing so.
