### PR TITLE
Revert commit 29e39e: don't build docs as their own derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,3 @@
 args@{ compiler ? "ghc928" }:
 let pkg = import ./servant-routes.nix args;
-in {
-  inherit (pkg) servant-routes;
-  inherit (pkg.servant-routes) doc;
-}
+in  pkg.servant-routes


### PR DESCRIPTION
Revert 29e39ef4c9c54
