### PR TITLE
Fill in some holes in the test suite

### DIFF
--- a/servant-routes.cabal
+++ b/servant-routes.cabal
@@ -79,6 +79,7 @@ library
     Servant.API.Routes.Internal.Header
     Servant.API.Routes.Internal.Path
     Servant.API.Routes.Internal.Body
+    Servant.API.Routes.Internal.Route
   other-modules:
     Servant.API.Routes.Utils
   -- other-extensions:

--- a/servant-routes.cabal
+++ b/servant-routes.cabal
@@ -77,6 +77,7 @@ library
     Servant.API.Routes.Body
 
     Servant.API.Routes.Internal.Header
+    Servant.API.Routes.Internal.Param
     Servant.API.Routes.Internal.Path
     Servant.API.Routes.Internal.Body
     Servant.API.Routes.Internal.Route

--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -112,14 +112,14 @@ import "this" Servant.API.Routes.Utils
  path AND its method (since 2 routes can have the same path but different method).
  This newtype lets us represent this nested structure.
 -}
-newtype Routes = UnsafeRoutes
+newtype Routes = MkRoutes
   { unRoutes :: Map.Map Path (Map.Map Method Route)
   -- ^ Get the underlying 'Map.Map' of a t'Routes'.
   }
   deriving (Show, Eq)
 
 makeRoutes :: [Route] -> Routes
-makeRoutes = UnsafeRoutes . foldl' insert mempty
+makeRoutes = MkRoutes . foldl' insert mempty
   where
     insert acc r = Map.insertWith (<>) path subMap acc
       where

--- a/src/Servant/API/Routes/Internal/Param.hs
+++ b/src/Servant/API/Routes/Internal/Param.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+{- |
+Module      : Servant.API.Routes.Internal.Param
+Copyright   : (c) Frederick Pringle, 2024
+License     : BSD-3-Clause
+Maintainer  : freddyjepringle@gmail.com
+
+Internal module, subject to change.
+-}
+module Servant.API.Routes.Internal.Param
+  ( Param (..)
+  )
+where
+
+import Data.Aeson
+import Data.Function (on)
+import GHC.Generics
+import qualified Servant.Links as S
+
+{- | Newtype wrapper around servant's 'S.Param' so we can define a sensible
+'Eq' instance for it.
+-}
+newtype Param = Param
+  { unParam :: S.Param
+  }
+  deriving (Show) via S.Param
+
+instance Eq Param where
+  (==) = eq `on` unParam
+    where
+      S.SingleParam name1 rep1 `eq` S.SingleParam name2 rep2 =
+        name1 == name2 && rep1 == rep2
+      S.ArrayElemParam name1 rep1 `eq` S.ArrayElemParam name2 rep2 =
+        name1 == name2 && rep1 == rep2
+      S.FlagParam name1 `eq` S.FlagParam name2 =
+        name1 == name2
+      _ `eq` _ = False
+
+data ParamType
+  = SingleParam
+  | ArrayElemParam
+  | FlagParam
+  deriving (Show, Eq, Enum, Bounded, Generic)
+  deriving (ToJSON)
+
+instance ToJSON Param where
+  toJSON (Param p) =
+    object $ case p of
+      S.SingleParam name rep ->
+        withType SingleParam ["name" .= name, "param_type" .= rep]
+      S.ArrayElemParam name rep ->
+        withType ArrayElemParam ["name" .= name, "param_type" .= rep]
+      S.FlagParam name ->
+        withType FlagParam ["name" .= name]
+    where
+      withType t ps = ("type" .= t) : ps

--- a/src/Servant/API/Routes/Internal/Route.hs
+++ b/src/Servant/API/Routes/Internal/Route.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+Module      : Servant.API.Routes.Internal.Route
+Copyright   : (c) Frederick Pringle, 2024
+License     : BSD-3-Clause
+Maintainer  : freddyjepringle@gmail.com
+
+Internal module, subject to change.
+-}
+module Servant.API.Routes.Internal.Route
+  ( -- * API routes
+    Route (..)
+
+    -- * Optics #optics#
+  , routeMethod
+  , routePath
+  , routeParams
+  , routeRequestHeaders
+  , routeRequestBody
+  , routeResponseHeaders
+  , routeResponseType
+  , routeAuths
+  )
+where
+
+import Data.Aeson
+import qualified Data.Aeson.Key as AK (fromText)
+import Data.Function (on)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Lens.Micro.TH
+import Network.HTTP.Types.Method (Method)
+import "this" Servant.API.Routes.Header
+import "this" Servant.API.Routes.Internal.Body
+import "this" Servant.API.Routes.Param
+import "this" Servant.API.Routes.Path
+import "this" Servant.API.Routes.Utils
+
+{- | A simple representation of a single endpoint of an API.
+
+The 'Route' type is not sophisticated, and its internals are hidden.
+Create 'Route's using 'defRoute', and update its fields using the provided [lenses](#g:optics).
+-}
+data Route = Route
+  { _routeMethod :: Method
+  , _routePath :: Path
+  , _routeParams :: [Param]
+  , _routeRequestHeaders :: [HeaderRep]
+  , _routeRequestBody :: Body
+  , _routeResponseHeaders :: [HeaderRep]
+  , _routeResponseType :: Body
+  , _routeAuths :: [T.Text]
+  }
+  deriving (Show, Eq)
+
+makeLenses ''Route
+
+instance Ord Route where
+  compare = compare `on` \Route {..} -> (_routePath, _routeMethod)
+
+bodyToJSONAs :: T.Text -> Body -> Value
+bodyToJSONAs lbl = \case
+  NoBody -> Null
+  OneType tRep -> typeRepToJSON tRep
+  ManyTypes tReps ->
+    object [AK.fromText lbl .= fmap typeRepToJSON tReps]
+
+instance ToJSON Route where
+  toJSON Route {..} =
+    object
+      [ "method" .= TE.decodeUtf8 _routeMethod
+      , "path" .= _routePath
+      , "params" .= _routeParams
+      , "request_headers" .= _routeRequestHeaders
+      , "request_body" .= bodyToJSONAs "all_of" _routeRequestBody
+      , "response_headers" .= _routeResponseHeaders
+      , "response" .= bodyToJSONAs "one_of" _routeResponseType
+      , "auths" .= _routeAuths
+      ]

--- a/src/Servant/API/Routes/Route.hs
+++ b/src/Servant/API/Routes/Route.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 {- |
 Module      : Servant.API.Routes.Route
 Copyright   : (c) Frederick Pringle, 2024
@@ -26,40 +24,12 @@ module Servant.API.Routes.Route
   )
 where
 
-import Data.Aeson
-import qualified Data.Aeson.Key as AK (fromText)
-import Data.Function (on)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Lens.Micro.TH
 import Network.HTTP.Types.Method (Method)
-import "this" Servant.API.Routes.Header
-import "this" Servant.API.Routes.Internal.Body
+import "this" Servant.API.Routes.Internal.Route
 import "this" Servant.API.Routes.Param
 import "this" Servant.API.Routes.Path
-import "this" Servant.API.Routes.Utils
-
-{- | A simple representation of a single endpoint of an API.
-
-The 'Route' type is not sophisticated, and its internals are hidden.
-Create 'Route's using 'defRoute', and update its fields using the provided [lenses](#g:optics).
--}
-data Route = Route
-  { _routeMethod :: Method
-  , _routePath :: Path
-  , _routeParams :: [Param]
-  , _routeRequestHeaders :: [HeaderRep]
-  , _routeRequestBody :: Body
-  , _routeResponseHeaders :: [HeaderRep]
-  , _routeResponseType :: Body
-  , _routeAuths :: [T.Text]
-  }
-  deriving (Show, Eq)
-
-makeLenses ''Route
-
-instance Ord Route where
-  compare = compare `on` \Route {..} -> (_routePath, _routeMethod)
 
 {- | Given a REST 'Method', create a default 'Route': root path (@"/"@) with no params,
 headers, body, auths, or response.
@@ -105,23 +75,3 @@ showRoute Route {..} =
       if null _routeParams
         then ""
         else "?" <> T.intercalate "&" (renderParam <$> _routeParams)
-
-bodyToJSONAs :: T.Text -> Body -> Value
-bodyToJSONAs lbl = \case
-  NoBody -> Null
-  OneType tRep -> typeRepToJSON tRep
-  ManyTypes tReps ->
-    object [AK.fromText lbl .= fmap typeRepToJSON tReps]
-
-instance ToJSON Route where
-  toJSON Route {..} =
-    object
-      [ "method" .= TE.decodeUtf8 _routeMethod
-      , "path" .= _routePath
-      , "params" .= _routeParams
-      , "request_headers" .= _routeRequestHeaders
-      , "request_body" .= bodyToJSONAs "all_of" _routeRequestBody
-      , "response_headers" .= _routeResponseHeaders
-      , "response" .= bodyToJSONAs "one_of" _routeResponseType
-      , "auths" .= _routeAuths
-      ]

--- a/test/Servant/API/Routes/HeaderSpec.hs
+++ b/test/Servant/API/Routes/HeaderSpec.hs
@@ -1,5 +1,6 @@
 module Servant.API.Routes.HeaderSpec
   ( spec
+  , sampleReps
   )
 where
 
@@ -19,7 +20,7 @@ spec = do
     it "should return an empty list for an empty type-level list" $
       getHeaderReps @'[] `shouldBe` []
     it "should recurse properly" $
-      getHeaderReps @'[H1, H2, H3] `shouldBe` HeaderRep "h1" intTypeRep : getHeaderReps @'[H2, H3]
+      sampleReps `shouldBe` HeaderRep "h1" intTypeRep : getHeaderReps @'[H2, H3]
 
 intTypeRep :: TypeRep
 intTypeRep = typeRep $ Proxy @Int
@@ -29,3 +30,6 @@ type H1 = Header "h1" Int
 type H2 = Header "h2" Char
 
 type H3 = Header "h3" [Integer]
+
+sampleReps :: [HeaderRep]
+sampleReps = getHeaderReps @'[H1, H2, H3]

--- a/test/Servant/API/Routes/PathSpec.hs
+++ b/test/Servant/API/Routes/PathSpec.hs
@@ -1,7 +1,4 @@
-module Servant.API.Routes.PathSpec
-  ( spec
-  )
-where
+module Servant.API.Routes.PathSpec where
 
 import qualified Data.Text as T
 import Servant.API.Routes.Internal.Path

--- a/test/Servant/API/Routes/RouteSpec.hs
+++ b/test/Servant/API/Routes/RouteSpec.hs
@@ -8,10 +8,51 @@ where
 import Data.Function
 import qualified Data.Text as T
 import Lens.Micro
+import Network.HTTP.Types.Method
+import Servant.API.Routes.BodySpec ()
+import Servant.API.Routes.HeaderSpec hiding (spec)
 import Servant.API.Routes.Internal.Path
-import "this" Servant.API.Routes.ParamSpec hiding (spec)
+import Servant.API.Routes.Internal.Route
+import Servant.API.Routes.ParamSpec hiding (spec)
+import Servant.API.Routes.PathSpec (genPathPart, shrinkPathPart)
 import Servant.API.Routes.Route
 import Test.Hspec as H
+import Test.QuickCheck as Q
+
+instance Q.Arbitrary Route where
+  arbitrary = do
+    _routeMethod <- renderStdMethod <$> Q.arbitraryBoundedEnum
+    _routePath <- arbitrary
+    _routeParams <- Q.sublistOf [sing, arrayElem, flag]
+    _routeRequestHeaders <- Q.sublistOf sampleReps
+    _routeRequestBody <- arbitrary
+    _routeResponseHeaders <- Q.sublistOf sampleReps
+    _routeResponseType <- arbitrary
+    _routeAuths <- Q.listOf genAuths
+
+    pure Route {..}
+    where
+      genAuths =
+        Q.oneof
+          [ ("Basic " <>) <$> genPathPart
+          , genPathPart
+          ]
+
+  shrink r =
+    routeMethod shrinkMethod r
+      <> routePath Q.shrink r
+      <> routeParams shrinkSublist r
+      <> routeRequestHeaders shrinkSublist r
+      <> routeRequestBody Q.shrink r
+      <> routeResponseHeaders shrinkSublist r
+      <> routeResponseType Q.shrink r
+      <> routeAuths (Q.shrinkList shrinkAuth) r
+    where
+      shrinkMethod = either (const []) (fmap renderStdMethod . Q.shrinkBoundedEnum) . parseMethod
+      shrinkSublist = Q.shrinkList (const [])
+      shrinkAuth auth = case T.stripPrefix "Basic " auth of
+        Nothing -> shrinkPathPart auth
+        Just realm -> ("Basic " <>) <$> shrinkPathPart realm
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
- Move `Route` definition to its own module so we can import the constructor in test suite
- Move `Param` definition to its own module so we can import the constructor in test suite
- `s/UnsafeRoutes/MkRoutes/g`
- Missing `Arbitrary` instances and helpers
- Missing `(un)makeRoutes` test
