### PR TITLE
Better representation for path parts

### DIFF
--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -318,20 +318,20 @@ instance (KnownSymbol path, HasRoutes api) => HasRoutes (path :> api) where
       path = knownSymbolT @path
 
 instance
-  (Typeable a, HasRoutes api) =>
+  (KnownSymbol capture, Typeable a, HasRoutes api) =>
   HasRoutes (Capture' mods capture a :> api)
   where
-  getRoutes = getRoutes @api <&> routePath %~ prependPathPart capture
+  getRoutes = getRoutes @api <&> routePath %~ prependCapturePart @a capture
     where
-      capture = "<" <> showTypeRep @a <> ">"
+      capture = knownSymbolT @capture
 
 instance
-  (Typeable [a], HasRoutes api) =>
+  (KnownSymbol capture, Typeable a, HasRoutes api) =>
   HasRoutes (CaptureAll capture a :> api)
   where
-  getRoutes = getRoutes @api <&> routePath %~ prependPathPart capture
+  getRoutes = getRoutes @api <&> routePath %~ prependCaptureAllPart @a capture
     where
-      capture = "<" <> showTypeRep @[a] <> ">"
+      capture = knownSymbolT @capture
 
 instance
   (KnownSymbol sym, Typeable (RequiredArgument mods a), HasRoutes api) =>

--- a/src/Servant/API/Routes/Internal/Path.hs
+++ b/src/Servant/API/Routes/Internal/Path.hs
@@ -12,27 +12,54 @@ module Servant.API.Routes.Internal.Path
   ( Path (..)
   , renderPath
   , pathSeparator
+  , PathPart (..)
   )
 where
 
 import Data.Aeson
+import Data.String
 import qualified Data.Text as T
+import Data.Typeable
+
+-- | A segment of an API path (between @"/"@s).
+data PathPart
+  = -- | Just a plain path part, e.g. @"api/"@.
+    StringPart T.Text
+  | -- | Capture a path part as a variable.
+    CapturePart T.Text TypeRep
+  | -- | Capture all path part as a list of variables.
+    CaptureAllPart T.Text TypeRep
+  deriving (Eq, Ord)
+
+instance IsString PathPart where
+  fromString = StringPart . T.pack
+
+instance Show PathPart where
+  show = T.unpack . renderPathPart
+
+-- | Pretty-print a path part.
+renderPathPart :: PathPart -> T.Text
+renderPathPart = \case
+  StringPart t -> t
+  CapturePart _ typ -> "<" <> T.pack (show typ) <> ">"
+  CaptureAllPart _ typ -> "<[" <> T.pack (show typ) <> "]>"
 
 -- | Standard path separator @"/"@.
 pathSeparator :: T.Text
 pathSeparator = "/"
 
-{- | Simple representation of a URL path. The constructor and fields are not exported since I
-may change the internal implementation in the future to use 'T.Text' instead of @['T.Text']@.
--}
+-- | Simple representation of a URL path.
 newtype Path = Path
-  { unPath :: [T.Text]
+  { unPath :: [PathPart]
   }
-  deriving (Show, Eq, Ord) via [T.Text]
+  deriving (Eq, Ord) via [PathPart]
+
+instance Show Path where
+  show = T.unpack . renderPath
 
 instance ToJSON Path where
   toJSON = toJSON . renderPath
 
 -- | Pretty-print a path, including the leading @/@.
 renderPath :: Path -> T.Text
-renderPath = (pathSeparator <>) . T.intercalate pathSeparator . unPath
+renderPath = (pathSeparator <>) . T.intercalate pathSeparator . fmap renderPathPart . unPath

--- a/src/Servant/API/Routes/Path.hs
+++ b/src/Servant/API/Routes/Path.hs
@@ -9,21 +9,60 @@ Simple representation of URL paths.
 module Servant.API.Routes.Path
   ( Path
   , prependPathPart
+  , prependCapturePart
+  , prependCaptureAllPart
   , renderPath
   , rootPath
   )
 where
 
 import qualified Data.Text as T
+import Data.Typeable
 import "this" Servant.API.Routes.Internal.Path
+import "this" Servant.API.Routes.Utils
 
 -- | @"/"@
 rootPath :: Path
 rootPath = Path []
 
--- | Equivalent to @(:)@.
+{- | Prepend a simple text path part to an API path.
+
+For example, @prependPathPart "api"@ will transform @\/v2\/users@ to @\/api\/v2\/users@.
+-}
 prependPathPart :: T.Text -> Path -> Path
 prependPathPart part (Path parts) =
   Path (splitParts <> parts)
   where
-    splitParts = filter (not . T.null) $ T.splitOn pathSeparator part
+    splitParts = fmap StringPart . filter (not . T.null) $ T.splitOn pathSeparator part
+
+{- | Prepend a capture path part of a given type to an API path.
+Equivalent to @'Servant.API.Capture' name a :>@.
+
+For example, @prependCapturePart \@Int "id"@ will transform @\/detail@ to @\/\<Int>\/detail@.
+-}
+prependCapturePart ::
+  forall a.
+  Typeable a =>
+  T.Text ->
+  Path ->
+  Path
+prependCapturePart name (Path parts) =
+  Path (capture : parts)
+  where
+    capture = CapturePart name $ typeRepOf @a
+
+{- | Prepend a capture-all path part of a given type to an API path.
+Equivalent to @'Servant.API.CaptureAll' name a :>@.
+
+For example, @prependCaptureAllPart \@Int "id"@ will transform @\/detail@ to @\/\<[Int]>\/detail@.
+-}
+prependCaptureAllPart ::
+  forall a.
+  Typeable a =>
+  T.Text ->
+  Path ->
+  Path
+prependCaptureAllPart name (Path parts) =
+  Path (capture : parts)
+  where
+    capture = CaptureAllPart name $ typeRepOf @a

--- a/test/Servant/API/RoutesSpec.hs
+++ b/test/Servant/API/RoutesSpec.hs
@@ -163,10 +163,15 @@ spec = do
         getRoutes @(ReqBody '[JSON] Int :> SubAPI2) `shouldMatchList` addB <$> getRoutes @SubAPI2
         getRoutes @(StreamBody NoFraming JSON Int :> SubAPI3) `shouldMatchList` addB <$> getRoutes @SubAPI3
       it "Capture' :>" $ do
-        let addC = routePath %~ prependPathPart "<Int>"
+        let addC = routePath %~ prependCapturePart @Int "cap"
         getRoutes @(Capture "cap" Int :> SubAPI) `shouldMatchList` addC <$> getRoutes @SubAPI
         getRoutes @(Capture "cap" Int :> SubAPI2) `shouldMatchList` addC <$> getRoutes @SubAPI2
         getRoutes @(Capture "cap" Int :> SubAPI3) `shouldMatchList` addC <$> getRoutes @SubAPI3
+      it "CaptureAll :>" $ do
+        let addC = routePath %~ prependCaptureAllPart @Int "cap"
+        getRoutes @(CaptureAll "cap" Int :> SubAPI) `shouldMatchList` addC <$> getRoutes @SubAPI
+        getRoutes @(CaptureAll "cap" Int :> SubAPI2) `shouldMatchList` addC <$> getRoutes @SubAPI2
+        getRoutes @(CaptureAll "cap" Int :> SubAPI3) `shouldMatchList` addC <$> getRoutes @SubAPI3
 #if MIN_VERSION_servant(0,19,0)
       it "NamedRoutes" $
         getRoutes @(NamedRoutes API) `shouldMatchList` getRoutes @SubAPI <> getRoutes @SubAPI2 <> getRoutes @SubAPI3


### PR DESCRIPTION
Previously we were representing `Path` internally as a list of `Text`s.
Here we switch to an ADT for more expressive/accurate representation.
