### PR TITLE
Use `Set`s in `Route` instead of lists

### DIFF
--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -103,6 +103,7 @@ import qualified Data.Aeson.Types as A (Pair)
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldl', traverse_)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
@@ -402,7 +403,7 @@ instance
   (KnownSymbol sym, Typeable (RequiredArgument mods a), HasRoutes api) =>
   HasRoutes (QueryParam' mods sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeParams %~ (param :)
+  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
     where
       param = singleParam @sym @(RequiredArgument mods a)
 
@@ -410,7 +411,7 @@ instance
   (KnownSymbol sym, Typeable a, HasRoutes api) =>
   HasRoutes (QueryParams sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeParams %~ (param :)
+  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
     where
       param = arrayElemParam @sym @a
 
@@ -420,7 +421,7 @@ instance (HasRoutes (ToServantApi routes)) => HasRoutes (NamedRoutes routes) whe
 #endif
 
 instance (KnownSymbol sym, HasRoutes api) => HasRoutes (QueryFlag sym :> api) where
-  getRoutes = getRoutes @api <&> routeParams %~ (param :)
+  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
     where
       param = flagParam @sym
 
@@ -436,7 +437,7 @@ instance (HasRoutes api) => HasRoutes (HttpVersion :> api) where
   getRoutes = getRoutes @api
 
 instance (HasRoutes api, KnownSymbol realm) => HasRoutes (BasicAuth realm usr :> api) where
-  getRoutes = getRoutes @api <&> routeAuths %~ (auth :)
+  getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
     where
       auth = "Basic " <> knownSymbolT @realm
 
@@ -450,7 +451,7 @@ instance
   (HasRoutes api, KnownSymbol tag) =>
   HasRoutes (AuthProtect (tag :: Symbol) :> api)
   where
-  getRoutes = getRoutes @api <&> routeAuths %~ (auth :)
+  getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
     where
       auth = knownSymbolT @tag
 
@@ -458,7 +459,7 @@ instance
   (HasRoutes api, KnownSymbol sym, Typeable (RequiredArgument mods a)) =>
   HasRoutes (Header' mods sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeRequestHeaders %~ (header :)
+  getRoutes = getRoutes @api <&> routeRequestHeaders %~ Set.insert header
     where
       header = mkHeaderRep @sym @(RequiredArgument mods a)
 

--- a/src/Servant/API/Routes/Internal/Param.hs
+++ b/src/Servant/API/Routes/Internal/Param.hs
@@ -37,6 +37,20 @@ instance Eq Param where
         name1 == name2
       _ `eq` _ = False
 
+instance Ord Param where
+  compare = comp `on` unParam
+    where
+      S.SingleParam name1 rep1 `comp` S.SingleParam name2 rep2 =
+        name1 `compare` name2 <> rep1 `compare` rep2
+      S.ArrayElemParam name1 rep1 `comp` S.ArrayElemParam name2 rep2 =
+        name1 `compare` name2 <> rep1 `compare` rep2
+      S.FlagParam name1 `comp` S.FlagParam name2 =
+        name1 `compare` name2
+      S.SingleParam {} `comp` _ = LT
+      _ `comp` S.SingleParam {} = LT
+      S.ArrayElemParam {} `comp` _ = LT
+      _ `comp` S.ArrayElemParam {} = LT
+
 data ParamType
   = SingleParam
   | ArrayElemParam

--- a/src/Servant/API/Routes/Internal/Route.hs
+++ b/src/Servant/API/Routes/Internal/Route.hs
@@ -25,6 +25,7 @@ where
 
 import Data.Aeson
 import Data.Function (on)
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Lens.Micro.TH
@@ -35,18 +36,16 @@ import "this" Servant.API.Routes.Internal.Response
 import "this" Servant.API.Routes.Param
 import "this" Servant.API.Routes.Path
 
-{- | A simple representation of a single endpoint of an API.
-
-TODO: these lists should be sets.
--}
+-- | A simple representation of a single endpoint of an API.
 data Route = Route
   { _routeMethod :: Method
   , _routePath :: Path
-  , _routeParams :: [Param]
-  , _routeRequestHeaders :: [HeaderRep]
+  , _routeParams :: Set.Set Param
+  , _routeRequestHeaders :: Set.Set HeaderRep
   , _routeRequestBody :: Request
   , _routeResponse :: Responses
-  , _routeAuths :: [T.Text]
+  , -- TODO: Auth type
+    _routeAuths :: Set.Set T.Text
   }
   deriving (Show, Eq)
 

--- a/src/Servant/API/Routes/Route.hs
+++ b/src/Servant/API/Routes/Route.hs
@@ -27,6 +27,7 @@ module Servant.API.Routes.Route
   )
 where
 
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Network.HTTP.Types.Method (Method)
@@ -44,7 +45,7 @@ defRoute method =
   Route
     { _routeMethod = method
     , _routePath = rootPath
-    , _routeParams = mempty
+    , _routeParams = Set.empty
     , _routeRequestHeaders = mempty
     , _routeRequestBody = noRequest
     , _routeResponse = noResponse
@@ -78,4 +79,4 @@ renderRoute Route {..} =
     params =
       if null _routeParams
         then ""
-        else "?" <> T.intercalate "&" (renderParam <$> _routeParams)
+        else "?" <> T.intercalate "&" (renderParam <$> Set.toList _routeParams)

--- a/test/Servant/API/Routes/RouteSpec.hs
+++ b/test/Servant/API/Routes/RouteSpec.hs
@@ -6,6 +6,7 @@ module Servant.API.Routes.RouteSpec
 where
 
 import Data.Function
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import Lens.Micro
 import Network.HTTP.Types.Method
@@ -24,11 +25,11 @@ instance Q.Arbitrary Route where
   arbitrary = do
     _routeMethod <- renderStdMethod <$> Q.arbitraryBoundedEnum
     _routePath <- arbitrary
-    _routeParams <- Q.sublistOf [sing, arrayElem, flag]
-    _routeRequestHeaders <- Q.sublistOf sampleReps
+    _routeParams <- Set.fromList <$> Q.sublistOf [sing, arrayElem, flag]
+    _routeRequestHeaders <- Set.fromList <$> Q.sublistOf sampleReps
     _routeRequestBody <- arbitrary
     _routeResponse <- arbitrary
-    _routeAuths <- Q.listOf genAuths
+    _routeAuths <- Set.fromList <$> Q.listOf genAuths
 
     pure Route {..}
     where
@@ -41,14 +42,16 @@ instance Q.Arbitrary Route where
   shrink r =
     routeMethod shrinkMethod r
       <> routePath Q.shrink r
-      <> routeParams shrinkSublist r
-      <> routeRequestHeaders shrinkSublist r
+      <> routeParams shrinkSubset r
+      <> routeRequestHeaders shrinkSubset r
       <> routeRequestBody Q.shrink r
       <> routeResponse Q.shrink r
-      <> routeAuths (Q.shrinkList shrinkAuth) r
+      <> routeAuths (shrinkSet shrinkAuth) r
     where
       shrinkMethod = either (const []) (fmap renderStdMethod . Q.shrinkBoundedEnum) . parseMethod
-      shrinkSublist = Q.shrinkList (const [])
+      shrinkSet shr = fmap Set.fromList . Q.shrinkList shr . Set.toList
+      shrinkSubset :: Ord a => Set.Set a -> [Set.Set a]
+      shrinkSubset = shrinkSet (const [])
       shrinkAuth auth = case T.stripPrefix "Basic " auth of
         Nothing -> shrinkText auth
         Just realm -> ("Basic " <>) <$> shrinkText realm
@@ -69,6 +72,6 @@ spec = do
         let route =
               defRoute "PUT"
                 & routePath .~ Path ["api", "v2"]
-                & routeParams .~ [sing, arrayElem, flag]
+                & routeParams .~ Set.fromList [sing, arrayElem, flag]
             expected = "PUT /api/v2?" <> T.intercalate "&" [singExpected, arrayElemExpected, flagExpected]
         in  renderRoute route `shouldBe` expected

--- a/test/Servant/API/RoutesSpec.hs
+++ b/test/Servant/API/RoutesSpec.hs
@@ -151,40 +151,40 @@ spec = do
         getRoutes @("sym" :> SubAPI2) `shouldMatchList` prep <$> getRoutes @SubAPI2
         getRoutes @("sym" :> SubAPI3) `shouldMatchList` prep <$> getRoutes @SubAPI3
       it "Header' :>" $ do
-        let addH = routeRequestHeaders %~ (mkHeaderRep @"h1" @Int :)
+        let addH = routeRequestHeaders %~ Set.insert (mkHeaderRep @"h1" @Int)
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI) `shouldMatchList` addH <$> getRoutes @SubAPI
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI2) `shouldMatchList` addH <$> getRoutes @SubAPI2
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI3) `shouldMatchList` addH <$> getRoutes @SubAPI3
-        let addHOptional = routeRequestHeaders %~ (mkHeaderRep @"h1" @(Maybe Int) :)
+        let addHOptional = routeRequestHeaders %~ Set.insert (mkHeaderRep @"h1" @(Maybe Int))
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI) `shouldMatchList` addHOptional <$> getRoutes @SubAPI
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI2) `shouldMatchList` addHOptional <$> getRoutes @SubAPI2
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI3) `shouldMatchList` addHOptional <$> getRoutes @SubAPI3
       it "BasicAuth :>" $ do
-        let addAuth = routeAuths %~ ("Basic realm" :)
+        let addAuth = routeAuths %~ Set.insert "Basic realm"
         getRoutes @(BasicAuth "realm" String :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(BasicAuth "realm" String :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(BasicAuth "realm" String :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3
       it "AuthProtect :>" $ do
-        let addAuth = routeAuths %~ ("my-special-auth" :)
+        let addAuth = routeAuths %~ Set.insert "my-special-auth"
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3
       it "QueryFlag :>" $ do
-        let addFlag = routeParams %~ (flagParam @"sym" :)
+        let addFlag = routeParams %~ Set.insert (flagParam @"sym")
         getRoutes @(QueryFlag "sym" :> SubAPI) `shouldMatchList` addFlag <$> getRoutes @SubAPI
         getRoutes @(QueryFlag "sym" :> SubAPI2) `shouldMatchList` addFlag <$> getRoutes @SubAPI2
         getRoutes @(QueryFlag "sym" :> SubAPI3) `shouldMatchList` addFlag <$> getRoutes @SubAPI3
       it "QueryParam' :>" $ do
-        let addP = routeParams %~ (singleParam @"h1" @Int :)
+        let addP = routeParams %~ Set.insert (singleParam @"h1" @Int)
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI) `shouldMatchList` addP <$> getRoutes @SubAPI
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI2) `shouldMatchList` addP <$> getRoutes @SubAPI2
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI3) `shouldMatchList` addP <$> getRoutes @SubAPI3
-        let addPOptional = routeParams %~ (singleParam @"h1" @(Maybe Int) :)
+        let addPOptional = routeParams %~ Set.insert (singleParam @"h1" @(Maybe Int))
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI) `shouldMatchList` addPOptional <$> getRoutes @SubAPI
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI2) `shouldMatchList` addPOptional <$> getRoutes @SubAPI2
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI3) `shouldMatchList` addPOptional <$> getRoutes @SubAPI3
       it "QueryParams :>" $ do
-        let addP = routeParams %~ (arrayElemParam @"h1" @Int :)
+        let addP = routeParams %~ Set.insert (arrayElemParam @"h1" @Int)
         getRoutes @(QueryParams "h1" Int :> SubAPI) `shouldMatchList` addP <$> getRoutes @SubAPI
         getRoutes @(QueryParams "h1" Int :> SubAPI2) `shouldMatchList` addP <$> getRoutes @SubAPI2
         getRoutes @(QueryParams "h1" Int :> SubAPI3) `shouldMatchList` addP <$> getRoutes @SubAPI3


### PR DESCRIPTION
The way that Servant (and HTTP in general) represents query params, request headers and auth schemes means that having duplicates doesn't really make sense. This PR changes those fields of `Route` to use `Set` instead of `[]`.