### PR TITLE
Better representation for auth schemes

### DIFF
--- a/servant-routes.cabal
+++ b/servant-routes.cabal
@@ -76,6 +76,7 @@ library
     Servant.API.Routes.Path
     Servant.API.Routes.Request
     Servant.API.Routes.Response
+    Servant.API.Routes.Auth
 
     Servant.API.Routes.Internal.Some
     Servant.API.Routes.Internal.Header
@@ -84,6 +85,7 @@ library
     Servant.API.Routes.Internal.Request
     Servant.API.Routes.Internal.Response
     Servant.API.Routes.Internal.Route
+    Servant.API.Routes.Internal.Auth
   other-modules:
     Servant.API.Routes.Utils
   -- other-extensions:

--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -93,6 +93,11 @@ module Servant.API.Routes
   , arrayElemParam
   , flagParam
   , renderParam
+
+    -- ** Auth schemes
+  , Auth
+  , basicAuth
+  , customAuth
   )
 where
 
@@ -114,6 +119,7 @@ import Lens.Micro
 import Network.HTTP.Types.Method (Method)
 import Servant.API
 import Servant.API.Modifiers (RequiredArgument)
+import "this" Servant.API.Routes.Auth
 import "this" Servant.API.Routes.Header
 import "this" Servant.API.Routes.Param
 import "this" Servant.API.Routes.Path
@@ -439,7 +445,7 @@ instance (HasRoutes api) => HasRoutes (HttpVersion :> api) where
 instance (HasRoutes api, KnownSymbol realm) => HasRoutes (BasicAuth realm usr :> api) where
   getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
     where
-      auth = "Basic " <> knownSymbolT @realm
+      auth = basicAuth @realm
 
 instance (HasRoutes api) => HasRoutes (Description sym :> api) where
   getRoutes = getRoutes @api
@@ -453,7 +459,7 @@ instance
   where
   getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
     where
-      auth = knownSymbolT @tag
+      auth = customAuth @tag
 
 instance
   (HasRoutes api, KnownSymbol sym, Typeable (RequiredArgument mods a)) =>

--- a/src/Servant/API/Routes/Auth.hs
+++ b/src/Servant/API/Routes/Auth.hs
@@ -1,0 +1,47 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+{- |
+Module      : Servant.API.Routes.Auth
+Copyright   : (c) Frederick Pringle, 2024
+License     : BSD-3-Clause
+Maintainer  : freddyjepringle@gmail.com
+
+Here we define a very very basic type to represent authentication schemes.
+-}
+module Servant.API.Routes.Auth
+  ( Auth
+  , basicAuth
+  , customAuth
+  )
+where
+
+import GHC.TypeLits (KnownSymbol)
+import "this" Servant.API.Routes.Internal.Auth
+import "this" Servant.API.Routes.Utils
+
+{- | Create a term-level representation of a \"Basic" authentication scheme.
+
+For example:
+
+> ghci> toJSON $ basicAuth @"user"
+> String "Basic user"
+-}
+basicAuth ::
+  forall realm.
+  KnownSymbol realm =>
+  Auth
+basicAuth = Basic $ knownSymbolT @realm
+
+{- | Create a term-level representation of a \"Custom" authentication scheme, i.e. one that
+corresponds to Servant's 'Servant.API.AuthProtect' combinator.
+
+For example:
+
+> ghci> toJSON $ customAuth @"OnlyAdminUsers"
+> String "OnlyAdminUsers"
+-}
+customAuth ::
+  forall tag.
+  KnownSymbol tag =>
+  Auth
+customAuth = Custom $ knownSymbolT @tag

--- a/src/Servant/API/Routes/Internal/Auth.hs
+++ b/src/Servant/API/Routes/Internal/Auth.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS_HADDOCK not-home #-}
+
+{- |
+Module      : Servant.API.Routes.Internal.Auth
+Copyright   : (c) Frederick Pringle, 2024
+License     : BSD-3-Clause
+Maintainer  : freddyjepringle@gmail.com
+
+Internal module, subject to change.
+-}
+module Servant.API.Routes.Internal.Auth
+  ( Auth (..)
+  )
+where
+
+import Data.Aeson
+import qualified Data.Text as T
+
+{- | There are 2 variants:
+
+- \"Basic" authentication: corresponds to the 'Servant.API.BasicAuth' type. Construct with 'Servant.API.Routes.Auth.basicAuth'.
+- \"Custom" authentication: corresponds to the 'Servant.API.AuthProtect' type. Construct with 'Servant.API.Routes.Auth.customAuth'.
+-}
+data Auth
+  = Basic T.Text
+  | Custom T.Text
+  deriving (Show, Eq, Ord)
+
+instance ToJSON Auth where
+  toJSON =
+    toJSON @T.Text . \case
+      Basic realm -> "Basic " <> realm
+      Custom tag -> tag

--- a/src/Servant/API/Routes/Internal/Route.hs
+++ b/src/Servant/API/Routes/Internal/Route.hs
@@ -26,10 +26,10 @@ where
 import Data.Aeson
 import Data.Function (on)
 import qualified Data.Set as Set
-import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Lens.Micro.TH
 import Network.HTTP.Types.Method (Method)
+import "this" Servant.API.Routes.Auth
 import "this" Servant.API.Routes.Header
 import "this" Servant.API.Routes.Internal.Request
 import "this" Servant.API.Routes.Internal.Response
@@ -44,8 +44,7 @@ data Route = Route
   , _routeRequestHeaders :: Set.Set HeaderRep
   , _routeRequestBody :: Request
   , _routeResponse :: Responses
-  , -- TODO: Auth type
-    _routeAuths :: Set.Set T.Text
+  , _routeAuths :: Set.Set Auth
   }
   deriving (Show, Eq)
 

--- a/test/Servant/API/Routes/RouteSpec.hs
+++ b/test/Servant/API/Routes/RouteSpec.hs
@@ -11,6 +11,7 @@ import qualified Data.Text as T
 import Lens.Micro
 import Network.HTTP.Types.Method
 import Servant.API.Routes.HeaderSpec hiding (spec)
+import Servant.API.Routes.Internal.Auth
 import Servant.API.Routes.Internal.Path
 import Servant.API.Routes.Internal.Route
 import Servant.API.Routes.ParamSpec hiding (spec)
@@ -35,8 +36,8 @@ instance Q.Arbitrary Route where
     where
       genAuths =
         Q.oneof
-          [ ("Basic " <>) <$> genAlphaText
-          , genAlphaText
+          [ Basic <$> genAlphaText
+          , Custom <$> genAlphaText
           ]
 
   shrink r =
@@ -52,9 +53,9 @@ instance Q.Arbitrary Route where
       shrinkSet shr = fmap Set.fromList . Q.shrinkList shr . Set.toList
       shrinkSubset :: Ord a => Set.Set a -> [Set.Set a]
       shrinkSubset = shrinkSet (const [])
-      shrinkAuth auth = case T.stripPrefix "Basic " auth of
-        Nothing -> shrinkText auth
-        Just realm -> ("Basic " <>) <$> shrinkText realm
+      shrinkAuth = \case
+        Basic realm -> Basic <$> shrinkText realm
+        Custom tag -> Custom <$> shrinkText tag
 
 spec :: Spec
 spec = do

--- a/test/Servant/API/RoutesSpec.hs
+++ b/test/Servant/API/RoutesSpec.hs
@@ -160,12 +160,12 @@ spec = do
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI2) `shouldMatchList` addHOptional <$> getRoutes @SubAPI2
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI3) `shouldMatchList` addHOptional <$> getRoutes @SubAPI3
       it "BasicAuth :>" $ do
-        let addAuth = routeAuths %~ Set.insert "Basic realm"
+        let addAuth = routeAuths %~ Set.insert (basicAuth @"realm")
         getRoutes @(BasicAuth "realm" String :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(BasicAuth "realm" String :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(BasicAuth "realm" String :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3
       it "AuthProtect :>" $ do
-        let addAuth = routeAuths %~ Set.insert "my-special-auth"
+        let addAuth = routeAuths %~ Set.insert (customAuth @"my-special-auth")
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3


### PR DESCRIPTION
Use an ADT type to represent auth schemes, more similar to Servant's `BasicAuth`/`AuthProtect`.
