### PR TITLE
The `add` lens action makes adding elements to sets more ergonomic

### DIFF
--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -108,7 +108,6 @@ import qualified Data.Aeson.Types as A (Pair)
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldl', traverse_)
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
@@ -409,7 +408,7 @@ instance
   (KnownSymbol sym, Typeable (RequiredArgument mods a), HasRoutes api) =>
   HasRoutes (QueryParam' mods sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
+  getRoutes = getRoutes @api <&> routeParams `add` param
     where
       param = singleParam @sym @(RequiredArgument mods a)
 
@@ -417,7 +416,7 @@ instance
   (KnownSymbol sym, Typeable a, HasRoutes api) =>
   HasRoutes (QueryParams sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
+  getRoutes = getRoutes @api <&> routeParams `add` param
     where
       param = arrayElemParam @sym @a
 
@@ -427,7 +426,7 @@ instance (HasRoutes (ToServantApi routes)) => HasRoutes (NamedRoutes routes) whe
 #endif
 
 instance (KnownSymbol sym, HasRoutes api) => HasRoutes (QueryFlag sym :> api) where
-  getRoutes = getRoutes @api <&> routeParams %~ Set.insert param
+  getRoutes = getRoutes @api <&> routeParams `add` param
     where
       param = flagParam @sym
 
@@ -443,7 +442,7 @@ instance (HasRoutes api) => HasRoutes (HttpVersion :> api) where
   getRoutes = getRoutes @api
 
 instance (HasRoutes api, KnownSymbol realm) => HasRoutes (BasicAuth realm usr :> api) where
-  getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
+  getRoutes = getRoutes @api <&> routeAuths `add` auth
     where
       auth = basicAuth @realm
 
@@ -457,7 +456,7 @@ instance
   (HasRoutes api, KnownSymbol tag) =>
   HasRoutes (AuthProtect (tag :: Symbol) :> api)
   where
-  getRoutes = getRoutes @api <&> routeAuths %~ Set.insert auth
+  getRoutes = getRoutes @api <&> routeAuths `add` auth
     where
       auth = customAuth @tag
 
@@ -465,7 +464,7 @@ instance
   (HasRoutes api, KnownSymbol sym, Typeable (RequiredArgument mods a)) =>
   HasRoutes (Header' mods sym a :> api)
   where
-  getRoutes = getRoutes @api <&> routeRequestHeaders %~ Set.insert header
+  getRoutes = getRoutes @api <&> routeRequestHeaders `add` header
     where
       header = mkHeaderRep @sym @(RequiredArgument mods a)
 

--- a/src/Servant/API/Routes/Route.hs
+++ b/src/Servant/API/Routes/Route.hs
@@ -24,12 +24,14 @@ module Servant.API.Routes.Route
   , routeRequestBody
   , routeResponse
   , routeAuths
+  , add
   )
 where
 
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Lens.Micro
 import Network.HTTP.Types.Method (Method)
 import "this" Servant.API.Routes.Internal.Route
 import "this" Servant.API.Routes.Param
@@ -80,3 +82,6 @@ renderRoute Route {..} =
       if null _routeParams
         then ""
         else "?" <> T.intercalate "&" (renderParam <$> Set.toList _routeParams)
+
+add :: Ord a => ASetter s t (Set.Set a) (Set.Set a) -> a -> s -> t
+add setter = over setter . Set.insert

--- a/test/Servant/API/RoutesSpec.hs
+++ b/test/Servant/API/RoutesSpec.hs
@@ -118,8 +118,8 @@ spec = do
                                             ]
                                      )
                                     <> ( intResponse
-                                          & unResponses . traversed . responseHeaders
-                                            %~ Set.insert (mkHeaderRep @"h2" @String)
+                                          & (unResponses . traversed . responseHeaders)
+                                            `add` (mkHeaderRep @"h2" @String)
                                        )
                             ]
       it "Verb" $ do
@@ -151,40 +151,40 @@ spec = do
         getRoutes @("sym" :> SubAPI2) `shouldMatchList` prep <$> getRoutes @SubAPI2
         getRoutes @("sym" :> SubAPI3) `shouldMatchList` prep <$> getRoutes @SubAPI3
       it "Header' :>" $ do
-        let addH = routeRequestHeaders %~ Set.insert (mkHeaderRep @"h1" @Int)
+        let addH = routeRequestHeaders `add` (mkHeaderRep @"h1" @Int)
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI) `shouldMatchList` addH <$> getRoutes @SubAPI
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI2) `shouldMatchList` addH <$> getRoutes @SubAPI2
         getRoutes @(Header' '[Required] "h1" Int :> SubAPI3) `shouldMatchList` addH <$> getRoutes @SubAPI3
-        let addHOptional = routeRequestHeaders %~ Set.insert (mkHeaderRep @"h1" @(Maybe Int))
+        let addHOptional = routeRequestHeaders `add` (mkHeaderRep @"h1" @(Maybe Int))
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI) `shouldMatchList` addHOptional <$> getRoutes @SubAPI
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI2) `shouldMatchList` addHOptional <$> getRoutes @SubAPI2
         getRoutes @(Header' '[Optional] "h1" Int :> SubAPI3) `shouldMatchList` addHOptional <$> getRoutes @SubAPI3
       it "BasicAuth :>" $ do
-        let addAuth = routeAuths %~ Set.insert (basicAuth @"realm")
+        let addAuth = routeAuths `add` basicAuth @"realm"
         getRoutes @(BasicAuth "realm" String :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(BasicAuth "realm" String :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(BasicAuth "realm" String :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3
       it "AuthProtect :>" $ do
-        let addAuth = routeAuths %~ Set.insert (customAuth @"my-special-auth")
+        let addAuth = routeAuths `add` customAuth @"my-special-auth"
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI) `shouldMatchList` addAuth <$> getRoutes @SubAPI
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI2) `shouldMatchList` addAuth <$> getRoutes @SubAPI2
         getRoutes @(AuthProtect "my-special-auth" :> SubAPI3) `shouldMatchList` addAuth <$> getRoutes @SubAPI3
       it "QueryFlag :>" $ do
-        let addFlag = routeParams %~ Set.insert (flagParam @"sym")
+        let addFlag = routeParams `add` (flagParam @"sym")
         getRoutes @(QueryFlag "sym" :> SubAPI) `shouldMatchList` addFlag <$> getRoutes @SubAPI
         getRoutes @(QueryFlag "sym" :> SubAPI2) `shouldMatchList` addFlag <$> getRoutes @SubAPI2
         getRoutes @(QueryFlag "sym" :> SubAPI3) `shouldMatchList` addFlag <$> getRoutes @SubAPI3
       it "QueryParam' :>" $ do
-        let addP = routeParams %~ Set.insert (singleParam @"h1" @Int)
+        let addP = routeParams `add` (singleParam @"h1" @Int)
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI) `shouldMatchList` addP <$> getRoutes @SubAPI
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI2) `shouldMatchList` addP <$> getRoutes @SubAPI2
         getRoutes @(QueryParam' '[Required] "h1" Int :> SubAPI3) `shouldMatchList` addP <$> getRoutes @SubAPI3
-        let addPOptional = routeParams %~ Set.insert (singleParam @"h1" @(Maybe Int))
+        let addPOptional = routeParams `add` (singleParam @"h1" @(Maybe Int))
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI) `shouldMatchList` addPOptional <$> getRoutes @SubAPI
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI2) `shouldMatchList` addPOptional <$> getRoutes @SubAPI2
         getRoutes @(QueryParam' '[Optional] "h1" Int :> SubAPI3) `shouldMatchList` addPOptional <$> getRoutes @SubAPI3
       it "QueryParams :>" $ do
-        let addP = routeParams %~ Set.insert (arrayElemParam @"h1" @Int)
+        let addP = routeParams `add` (arrayElemParam @"h1" @Int)
         getRoutes @(QueryParams "h1" Int :> SubAPI) `shouldMatchList` addP <$> getRoutes @SubAPI
         getRoutes @(QueryParams "h1" Int :> SubAPI2) `shouldMatchList` addP <$> getRoutes @SubAPI2
         getRoutes @(QueryParams "h1" Int :> SubAPI3) `shouldMatchList` addP <$> getRoutes @SubAPI3


### PR DESCRIPTION
Whereas previously we would have done `routeRequestHeaders %~ Set.insert header`, we can now do
```haskell
routeRequestHeaders `add` header
```

This is a bit more ergonomic and abstracts the `Set` representation.
