### PR TITLE
Release v0.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+## [0.1.0.0] - 03.05.2025
+
 ### Added
 
-- First edition of the package, ready for feedback.
+- First edition of the package.
 - 100% documentation coverage.
 - Almost 100% test coverage.
 - Reasonably detailed README.
 - CI that builds and tests the package for each version of GHC in the `tested-with` field.
 
-[unreleased]: https://github.com/fpringle/servant-routes/compare/8be3d0b...HEAD
+[unreleased]: https://github.com/fpringle/servant-routes/compare/v0.1.0.0...HEAD
 [0.1.0.0]: https://github.com/fpringle/servant-routes/releases/tag/v0.1.0.0


### PR DESCRIPTION
Finally ready to release `v0.1.0.0` - changelog has been updated accordingly.