### PR TITLE
Sorted version of `printRoutes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- A function to sort `Route`s before printing them to stdout. [#32](https://github.com/fpringle/servant-routes/pull/32)
+
 ## [0.1.0.0] - 03.05.2025
 
 ### Added

--- a/src/Servant/API/Routes.hs
+++ b/src/Servant/API/Routes.hs
@@ -53,6 +53,7 @@ module Servant.API.Routes
     -- defining their own combinators.
   , HasRoutes (..)
   , printRoutes
+  , printRoutesSorted
   , printRoutesJSON
   , printRoutesJSONPretty
 
@@ -107,6 +108,7 @@ import qualified Data.Aeson.Key as AK (fromText)
 import qualified Data.Aeson.Types as A (Pair)
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldl', traverse_)
+import Data.List (sort)
 import qualified Data.Map as Map
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as T
@@ -279,6 +281,14 @@ class HasRoutes api where
 -- | Get all the routes of an API and print them to stdout. See 'renderRoute' for examples.
 printRoutes :: forall api. HasRoutes api => IO ()
 printRoutes = traverse_ printRoute $ getRoutes @api
+  where
+    printRoute = T.putStrLn . renderRoute
+
+{- | Get all the routes of an API, sort them by path and method, and print them to stdout.
+ See 'renderRoute' for examples.
+-}
+printRoutesSorted :: forall api. HasRoutes api => IO ()
+printRoutesSorted = traverse_ printRoute . sort $ getRoutes @api
   where
     printRoute = T.putStrLn . renderRoute
 


### PR DESCRIPTION
Closes #31.

---

- **Add a version of `printRoutes` that sorts the routes before printing them**
- **Update changelog**
