### PR TITLE
Fix a bug in the `Ord Param` instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 ### Added
 
 - A function to sort `Route`s before printing them to stdout. [#32](https://github.com/fpringle/servant-routes/pull/32)
+- More GHC versions in `tested-with`.
+
+### Fixed
+
+- Bug in the hand-rolled `Ord Param` instance.
 
 ## [0.1.0.0] - 03.05.2025
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57695599bdc4f7bfe5d28cfa23f14b3d8bdf8a5f",
-        "sha256": "0wxfwl5cqkq5sc4mrd09pysj60md8fvdd4y7fg8f0k52jq2s8r00",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "sha256": "09dahi81cn02gnzsc8a00n945dxc18656ar0ffx5vgxjj1nhgsvy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/57695599bdc4f7bfe5d28cfa23f14b3d8bdf8a5f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/servant-routes.cabal
+++ b/servant-routes.cabal
@@ -23,6 +23,11 @@ tested-with:
   , GHC == 9.2.8
   , GHC == 9.4.2
   , GHC == 9.4.5
+  , GHC == 9.6.1
+  , GHC == 9.6.7
+  , GHC == 9.8.2
+  , GHC == 9.10.2
+  , GHC == 9.12.2
 
 source-repository head
   type:           git

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
-args@{ compiler ? "ghc928"
+{ compiler ? "ghc928"
 }:
 let
-  inherit (import ./servant-routes.nix args)
+  inherit (import ./servant-routes.nix {inherit compiler;})
       nixpkgs sources servant-routes;
 
   pre-commit-check = import ./nix/pre-commit.nix;

--- a/src/Servant/API/Routes/Internal/Param.hs
+++ b/src/Servant/API/Routes/Internal/Param.hs
@@ -47,9 +47,9 @@ instance Ord Param where
       S.FlagParam name1 `comp` S.FlagParam name2 =
         name1 `compare` name2
       S.SingleParam {} `comp` _ = LT
-      _ `comp` S.SingleParam {} = LT
+      _ `comp` S.SingleParam {} = GT
       S.ArrayElemParam {} `comp` _ = LT
-      _ `comp` S.ArrayElemParam {} = LT
+      _ `comp` S.ArrayElemParam {} = GT
 
 data ParamType
   = SingleParam

--- a/test/Servant/API/Routes/ParamSpec.hs
+++ b/test/Servant/API/Routes/ParamSpec.hs
@@ -2,7 +2,9 @@ module Servant.API.Routes.ParamSpec where
 
 import qualified Data.Text as T
 import Servant.API.Routes.Param
+import Servant.API.Routes.Util
 import Test.Hspec as H
+import qualified Test.QuickCheck as Q
 
 sing, arrayElem, flag :: Param
 sing = singleParam @"sing_sym" @Int
@@ -14,6 +16,12 @@ singExpected = "sing_sym=<Int>"
 arrayElemExpected = "array_sym=<[Int]>"
 flagExpected = "flag_sym"
 
+newtype ParamBasicQInstance = ParamBasicQInstance Param
+  deriving (Show, Eq, Ord) via Param
+
+instance Q.Arbitrary ParamBasicQInstance where
+  arbitrary = ParamBasicQInstance <$> Q.elements [sing, arrayElem, flag]
+
 spec :: Spec
 spec = do
   describe "renderParam" $ do
@@ -23,3 +31,7 @@ spec = do
       renderParam arrayElem `shouldBe` arrayElemExpected
     it "should render flagParam correctly" $ do
       renderParam flag `shouldBe` flagExpected
+
+  describe "Hand-rolled instances" $ do
+    testEqInstances @ParamBasicQInstance
+    testOrdInstances @ParamBasicQInstance

--- a/test/Servant/API/Routes/RequestSpec.hs
+++ b/test/Servant/API/Routes/RequestSpec.hs
@@ -4,11 +4,11 @@ module Servant.API.Routes.RequestSpec
 where
 
 import Servant.API.Routes.Internal.Request
-import "this" Servant.API.Routes.SomeSpec hiding (spec)
 import Servant.API.Routes.Util
 import Test.Hspec as H
 import Test.Hspec.QuickCheck as H
 import Test.QuickCheck as Q
+import "this" Servant.API.Routes.SomeSpec hiding (spec)
 
 {- hlint ignore "Monoid law, right identity" -}
 {- hlint ignore "Monoid law, left identity" -}
@@ -31,3 +31,5 @@ spec = do
       \(xs :: [Request]) -> mconcat xs === foldr (<>) mempty xs
   it "AllTypeable" $ do
     typeReps @'[Int, String] `shouldMatchList` [intTypeRep, strTypeRep]
+  describe "Hand-rolled instances" $ do
+    testEqInstances @Request

--- a/test/Servant/API/Routes/ResponseSpec.hs
+++ b/test/Servant/API/Routes/ResponseSpec.hs
@@ -4,13 +4,13 @@ module Servant.API.Routes.ResponseSpec
 where
 
 import qualified Data.Set as Set
-import "this" Servant.API.Routes.HeaderSpec (sampleReps)
 import Servant.API.Routes.Internal.Response
-import "this" Servant.API.Routes.SomeSpec hiding (spec)
 import Servant.API.Routes.Util
 import Test.Hspec as H
 import Test.Hspec.QuickCheck as H
 import Test.QuickCheck as Q
+import "this" Servant.API.Routes.HeaderSpec (sampleReps)
+import "this" Servant.API.Routes.SomeSpec hiding (spec)
 
 {- hlint ignore "Monoid law, right identity" -}
 {- hlint ignore "Monoid law, left identity" -}
@@ -40,3 +40,6 @@ spec = do
       \(x :: Responses) -> mempty <> x === x
     prop "Concatentation" $ do
       \(xs :: [Responses]) -> mconcat xs === foldr (<>) mempty xs
+  describe "Hand-rolled instances" $ do
+    testEqInstances @Response
+    testEqInstances @Responses

--- a/test/Servant/API/Routes/RouteSpec.hs
+++ b/test/Servant/API/Routes/RouteSpec.hs
@@ -17,6 +17,7 @@ import Servant.API.Routes.PathSpec (genAlphaText, shrinkText)
 import Servant.API.Routes.RequestSpec ()
 import Servant.API.Routes.ResponseSpec ()
 import Servant.API.Routes.Route
+import Servant.API.Routes.Util
 import Test.Hspec as H
 import Test.QuickCheck as Q
 
@@ -49,7 +50,7 @@ instance Q.Arbitrary Route where
     where
       shrinkMethod = either (const []) (fmap renderStdMethod . Q.shrinkBoundedEnum) . parseMethod
       shrinkSet shr = fmap Set.fromList . Q.shrinkList shr . Set.toList
-      shrinkSubset :: Ord a => Set.Set a -> [Set.Set a]
+      shrinkSubset :: (Ord a) => Set.Set a -> [Set.Set a]
       shrinkSubset = shrinkSet (const [])
       shrinkAuth = \case
         Basic realm -> Basic <$> shrinkText realm
@@ -74,3 +75,6 @@ spec = do
                 & routeParams .~ Set.fromList [sing, arrayElem, flag]
             expected = "PUT /api/v2?" <> T.intercalate "&" [singExpected, arrayElemExpected, flagExpected]
         in  renderRoute route `shouldBe` expected
+  describe "Hand-rolled instances" $ do
+    testEqInstances @ParamBasicQInstance
+    testOrdInstances @ParamBasicQInstance

--- a/test/Servant/API/Routes/SomeSpec.hs
+++ b/test/Servant/API/Routes/SomeSpec.hs
@@ -25,7 +25,7 @@ genSome gen =
 shrinkSome :: (a -> [a]) -> Some a -> [Some a]
 shrinkSome shr = fmap S.fromList . Q.shrinkList shr . S.toList
 
-instance Q.Arbitrary a => Q.Arbitrary (Some a) where
+instance (Q.Arbitrary a) => Q.Arbitrary (Some a) where
   arbitrary = genSome arbitrary
   shrink = shrinkSome shrink
 
@@ -39,7 +39,7 @@ genAtLeast2 gen = do
   as <- Q.listOf gen
   pure . AtLeast2 $ a1 : a2 : as
 
-instance Arbitrary a => Arbitrary (AtLeast2 a) where
+instance (Arbitrary a) => Arbitrary (AtLeast2 a) where
   arbitrary = genAtLeast2 arbitrary
   shrink = fmap AtLeast2 . filter ((>= 2) . length) . shrink . unAtLeast2
 

--- a/test/Servant/API/Routes/Util.hs
+++ b/test/Servant/API/Routes/Util.hs
@@ -1,6 +1,9 @@
 module Servant.API.Routes.Util where
 
 import Data.Typeable
+import qualified Test.Hspec as H
+import qualified Test.Hspec.QuickCheck as H
+import qualified Test.QuickCheck as Q
 
 intTypeRep :: TypeRep
 intTypeRep = typeRep $ Proxy @Int
@@ -10,3 +13,27 @@ strTypeRep = typeRep $ Proxy @String
 
 unitTypeRep :: TypeRep
 unitTypeRep = typeRep $ Proxy @()
+
+{- HLINT ignore "Use /= -}
+
+testEqInstances :: forall a. (Q.Arbitrary a, Show a, Eq a) => H.Spec
+testEqInstances =
+  H.describe "Eq instance should satisfy laws" $ do
+    H.prop "Reflexivity" $ \(p1 :: a) ->
+      p1 Q.=== p1
+    H.prop "Symmetry" $ \(p1 :: a) p2 ->
+      (p1 == p2) Q.=== (p2 == p1)
+    H.prop "Negation" $ \(p1 :: a) p2 ->
+      (p1 /= p2) Q.=== not (p1 == p2)
+
+testOrdInstances :: forall a. (Q.Arbitrary a, Show a, Ord a) => H.Spec
+testOrdInstances =
+  H.describe "Ord instance should satisfy laws" $ do
+    H.prop "Comparability" $ \(p1 :: a) p2 ->
+      (p1 <= p2) Q..||. (p2 <= p1)
+    H.prop "Transitivity" $ \(p1 :: a) p2 p3 ->
+      (p1 <= p2 && p2 <= p3) Q.==> (p1 <= p3)
+    H.prop "Reflexivity" $ \(p1 :: a) ->
+      p1 <= p1
+    H.prop "Antisymmetry" $ \(p1 :: a) p2 ->
+      (p1 <= p2 && p2 <= p1) Q.==> (p1 Q.=== p2)


### PR DESCRIPTION
- **Update pinned `nixpkgs` revision, giving us access to more GHC versions for testing**
- **Fix a bug in how nix args were being passed down**
- **Add tests for hand-rolled `Eq` and `Ord` instances**
- **Fix a bug in the manual implementation of `Ord Param`**
- **Add more GHC versions to `tested-with`**
- **Update CHANGELOG**
