### PR TITLE
Support for `MultiVerb`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,5 @@ tests: True
 packages:
   servant-routes/
   servant-routes-golden/
+
+multi-repl: True

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -22,7 +22,9 @@ let
       haskell-overrides = hfinal: hprev:
         let
           # When we pin specific versions of Haskell packages, they'll go here using callCabal2Nix.
-          packageOverrides = { };
+          packageOverrides = {
+            servant = hfinal.callCabal2nix "servant" "${sources.servant}/servant" {};
+          };
 
           pkgMods = [ ];
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "servant": {
+        "branch": "master",
+        "description": "Servant is a Haskell DSL for describing, serving, querying, mocking, documenting web applications and more!",
+        "homepage": "https://docs.servant.dev/",
+        "owner": "haskell-servant",
+        "repo": "servant",
+        "rev": "e07e92abd62641fc0f199a33e5131de273140cb0",
+        "sha256": "0cx37nrqlylmsi5f75mqs8vlqnsn41qn94k3d9zl4lyczvmm8sfd",
+        "type": "tarball",
+        "url": "https://github.com/haskell-servant/servant/archive/e07e92abd62641fc0f199a33e5131de273140cb0.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
@@ -1,0 +1,71 @@
+{
+    "/multi1": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi1",
+            "request_body": null,
+            "request_headers": [],
+            "response": null,
+            "summary": null
+        }
+    },
+    "/multi2": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi2",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "description": "hello",
+                "headers": [],
+                "type": "Int"
+            },
+            "summary": null
+        }
+    },
+    "/multi3": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi3",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "description": "int",
+                "headers": [],
+                "type": "Int"
+            },
+            "summary": null
+        }
+    },
+    "/multi4": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi4",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "one_of": [
+                    {
+                        "description": "int",
+                        "headers": [],
+                        "type": "Int"
+                    },
+                    {
+                        "description": "string-streaming",
+                        "headers": [],
+                        "type": "[Char]"
+                    }
+                ]
+            },
+            "summary": null
+        }
+    }
+}

--- a/servant-routes-golden/servant-routes-golden.cabal
+++ b/servant-routes-golden/servant-routes-golden.cabal
@@ -97,3 +97,4 @@ test-suite servant-routes-golden-test
     , servant >= 0.17 && < 0.21
     , hspec >= 2.9 && < 2.12
     , QuickCheck >= 2.14 && < 2.16
+    , bytestring >= 0.11 && < 0.13

--- a/servant-routes-golden/test/Servant/API/Routes/GoldenSpec.hs
+++ b/servant-routes-golden/test/Servant/API/Routes/GoldenSpec.hs
@@ -6,9 +6,13 @@ module Servant.API.Routes.GoldenSpec
   )
 where
 
+import Data.ByteString
 import qualified Data.Text as T
 import GHC.Generics
 import Servant.API
+#if MIN_VERSION_servant(0,20,3)
+import Servant.API.MultiVerb
+#endif
 import Servant.API.Routes.Golden
 import Test.Hspec as H
 
@@ -31,6 +35,15 @@ data API mode = API
   } deriving Generic
 #endif
 
+#if MIN_VERSION_servant(0,20,3)
+data MultiAPI mode = MultiAPI
+  { multi1 :: mode :- "multi1" :> MultiVerb 'POST '[JSON] '[] (Union '[])
+  , multi2 :: mode :- "multi2" :> MultiVerb 'POST '[JSON] '[Respond 200 "hello" Int] Int
+  , multi3 :: mode :- "multi3" :> MultiVerb 'POST '[JSON] '[RespondAs '[JSON] 200 "int" Int] Int
+  , multi4 :: mode :- "multi4" :> MultiVerb 'POST '[JSON] '[RespondAs '[JSON] 200 "int" Int, RespondStreaming 200 "string-streaming" () String] (Union '[Int, SourceIO ByteString])
+  } deriving Generic
+#endif
+
 spec :: H.Spec
 spec = do
   it "SubAPI" $ goldenRoutes @SubAPI (show ''SubAPI)
@@ -38,4 +51,7 @@ spec = do
   it "SubAPI3" $ goldenRoutes @SubAPI3 (show ''SubAPI3)
 #if MIN_VERSION_servant(0,19,0)
   it "NamedRoutes API" $ goldenRoutes @(NamedRoutes API) (show ''API)
+#endif
+#if MIN_VERSION_servant(0,20,3)
+  it "MultiVerb API" $ goldenRoutes @(NamedRoutes MultiAPI) (show ''MultiAPI)
 #endif

--- a/servant-routes/CHANGELOG.md
+++ b/servant-routes/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- `HasRoutes` support for `MultiVerb`. [#44](https://github.com/fpringle/servant-routes/pull/44)
+
 ### Changed
 
 - `RouteDescription` is now called `ResponseDescription` and has moved from `Route` to `Response`. [#41](https://github.com/fpringle/servant-routes/pull/41)

--- a/servant-routes/servant-routes.cabal
+++ b/servant-routes/servant-routes.cabal
@@ -126,3 +126,4 @@ test-suite servant-routes-test
     , servant-routes
     , hspec >= 2.9 && < 2.12
     , QuickCheck >= 2.14 && < 2.15
+    , bytestring >= 0.11 && < 0.13

--- a/servant-routes/src/Servant/API/Routes/Utils.hs
+++ b/servant-routes/src/Servant/API/Routes/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PolyKinds #-}
+
 {- |
 Module      : Servant.API.Routes.Utils
 Copyright   : (c) Frederick Pringle, 2025


### PR DESCRIPTION
Following #41, we can now add support for servant's new [MultiVerb](https://hackage-content.haskell.org/package/servant-0.20.3.0/docs/Servant-API-MultiVerb.html#t:MultiVerb) combinator.

Note that this PR supports responses built using `Respond`, `RespondAs`, and `RespondStreaming`, but not `WithHeaders` (or `DescHeader`, `OptHeader`). These require more involved changes to the internals of `HeaderRep`, which will be done in a later PR.

Closes #42.