### PR TITLE
Support for `WithHeaders`

### DIFF
--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.API/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.API/golden
@@ -24,6 +24,7 @@
             "request_body": "[Char]",
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h1",
                     "type": "Maybe Text"
                 }
@@ -45,6 +46,7 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h1",
                     "type": "Maybe Text"
                 }
@@ -66,6 +68,7 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h2",
                     "type": "Maybe Text"
                 }
@@ -87,10 +90,12 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h2",
                     "type": "Maybe Text"
                 },
                 {
+                    "description": null,
                     "name": "h3",
                     "type": "Maybe Int"
                 }

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
@@ -67,5 +67,71 @@
             },
             "summary": null
         }
+    },
+    "/multi5": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi5",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "description": null,
+                "headers": [],
+                "type": "Int"
+            },
+            "summary": null
+        }
+    },
+    "/multi6": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi6",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "description": null,
+                "headers": [
+                    {
+                        "name": "h1",
+                        "type": "[Int]"
+                    },
+                    {
+                        "name": "h2",
+                        "type": "Maybe Char"
+                    }
+                ],
+                "type": "Int"
+            },
+            "summary": null
+        }
+    },
+    "/multi7": {
+        "POST": {
+            "auths": [],
+            "method": "POST",
+            "params": [],
+            "path": "/multi7",
+            "request_body": null,
+            "request_headers": [],
+            "response": {
+                "description": null,
+                "headers": [
+                    {
+                        "name": "h1",
+                        "type": "Maybe Char"
+                    },
+                    {
+                        "name": "h2",
+                        "type": "Maybe Char"
+                    }
+                ],
+                "type": "Int"
+            },
+            "summary": null
+        }
     }
 }

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
@@ -96,10 +96,12 @@
                 "description": null,
                 "headers": [
                     {
+                        "description": "",
                         "name": "h1",
                         "type": "[Int]"
                     },
                     {
+                        "description": "",
                         "name": "h2",
                         "type": "Maybe Char"
                     }
@@ -121,10 +123,12 @@
                 "description": null,
                 "headers": [
                     {
+                        "description": "",
                         "name": "h1",
                         "type": "Maybe Char"
                     },
                     {
+                        "description": "",
                         "name": "h2",
                         "type": "Maybe Char"
                     }

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI2/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI2/golden
@@ -8,6 +8,7 @@
             "request_body": "[Char]",
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h1",
                     "type": "Maybe Text"
                 }
@@ -29,6 +30,7 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h1",
                     "type": "Maybe Text"
                 }

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI3/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI3/golden
@@ -8,6 +8,7 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h2",
                     "type": "Maybe Text"
                 }
@@ -29,10 +30,12 @@
             "request_body": null,
             "request_headers": [
                 {
+                    "description": null,
                     "name": "h2",
                     "type": "Maybe Text"
                 },
                 {
+                    "description": null,
                     "name": "h3",
                     "type": "Maybe Int"
                 }

--- a/servant-routes-golden/test/Servant/API/Routes/GoldenSpec.hs
+++ b/servant-routes-golden/test/Servant/API/Routes/GoldenSpec.hs
@@ -39,9 +39,39 @@ data API mode = API
 data MultiAPI mode = MultiAPI
   { multi1 :: mode :- "multi1" :> MultiVerb 'POST '[JSON] '[] (Union '[])
   , multi2 :: mode :- "multi2" :> MultiVerb 'POST '[JSON] '[Respond 200 "hello" Int] Int
-  , multi3 :: mode :- "multi3" :> MultiVerb 'POST '[JSON] '[RespondAs '[JSON] 200 "int" Int] Int
-  , multi4 :: mode :- "multi4" :> MultiVerb 'POST '[JSON] '[RespondAs '[JSON] 200 "int" Int, RespondStreaming 200 "string-streaming" () String] (Union '[Int, SourceIO ByteString])
-  } deriving Generic
+  , multi3 ::
+      mode :- "multi3" :> MultiVerb 'POST '[JSON] '[RespondAs '[JSON] 200 "int" Int] Int
+  , multi4 ::
+      mode
+        :- "multi4"
+          :> MultiVerb
+              'POST
+              '[JSON]
+              '[ RespondAs '[JSON] 200 "int" Int
+               , RespondStreaming 200 "string-streaming" () String
+               ]
+              (Union '[Int, SourceIO ByteString])
+  , multi5 :: mode :- "multi5" :> MultiVerb 'POST '[JSON] '[WithHeaders '[] Int Int] Int
+  , multi6 ::
+      mode
+        :- "multi6"
+          :> MultiVerb
+              'POST
+              '[JSON]
+              '[ WithHeaders '[DescHeader "h1" "" [Int], OptHeader (DescHeader "h2" "" Char)] Int Int
+               ]
+              Int
+  , multi7 ::
+      mode
+        :- "multi7"
+          :> MultiVerb
+              'POST
+              '[JSON]
+              '[ WithHeaders '[OptHeader (DescHeader "h1" "" Char), OptHeader (OptHeader (DescHeader "h2" "" Char))] Int Int
+               ]
+              Int
+  }
+  deriving (Generic)
 #endif
 
 spec :: H.Spec

--- a/servant-routes/CHANGELOG.md
+++ b/servant-routes/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ### Added
 
-- `HasRoutes` support for `MultiVerb`. [#44](https://github.com/fpringle/servant-routes/pull/44)
+- `HasRoutes` support for `MultiVerb`. [#44](https://github.com/fpringle/servant-routes/pull/44), [#45](https://github.com/fpringle/servant-routes/pull/45)
 
 ### Changed
 

--- a/servant-routes/src/Servant/API/Routes/Header.hs
+++ b/servant-routes/src/Servant/API/Routes/Header.hs
@@ -9,6 +9,7 @@ Simple representation of HTTP headers.
 module Servant.API.Routes.Header
   ( HeaderRep
   , GetHeaderReps (..)
+  , GetHeaderRep (..)
   , mkHeaderRep
   )
 where

--- a/servant-routes/src/Servant/API/Routes/Internal/Header.hs
+++ b/servant-routes/src/Servant/API/Routes/Internal/Header.hs
@@ -108,12 +108,17 @@ instance
   getHeaderRep = mkHeaderRep @h @v
 
 #if MIN_VERSION_servant(0,20,3)
-instance (KnownSymbol name, Typeable v) =>
+instance
+  (KnownSymbol name, KnownSymbol desc, Typeable v) =>
   GetHeaderRep (DescHeader name desc v)
   where
-  getHeaderRep = mkHeaderRep @name @v
+  getHeaderRep =
+    (mkHeaderRep @name @v)
+      { _hDescription = Just (knownSymbolT @desc)
+      }
 
-instance (GetHeaderRep h) =>
+instance
+  (GetHeaderRep h) =>
   GetHeaderRep (OptHeader h)
   where
   getHeaderRep =

--- a/servant-routes/src/Servant/API/Routes/Internal/Header.hs
+++ b/servant-routes/src/Servant/API/Routes/Internal/Header.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_HADDOCK not-home #-}
@@ -24,6 +25,9 @@ import Data.Kind (Type)
 import Data.Text
 import GHC.TypeLits
 import Servant.API
+#if MIN_VERSION_servant(0,20,3)
+import Servant.API.MultiVerb
+#endif
 import Type.Reflection
 import "this" Servant.API.Routes.Utils
 
@@ -99,6 +103,20 @@ instance
   GetHeaderRep (Header h v)
   where
   getHeaderRep = mkHeaderRep @h @v
+
+#if MIN_VERSION_servant(0,20,3)
+instance (KnownSymbol name, Typeable v) =>
+  GetHeaderRep (DescHeader name desc v)
+  where
+  getHeaderRep = mkHeaderRep @name @v
+
+instance (GetHeaderRep h) =>
+  GetHeaderRep (OptHeader h)
+  where
+  getHeaderRep =
+    let hRep = getHeaderRep @h
+    in  mkHeaderRepOptional hRep
+#endif
 
 {- | Utility class to let us get a value-level list of 'HeaderRep's from a
 type-level list of 'Servant.API.Header.Header's. See the implementation of

--- a/servant-routes/src/Servant/API/Routes/Internal/Header.hs
+++ b/servant-routes/src/Servant/API/Routes/Internal/Header.hs
@@ -13,6 +13,7 @@ Internal module, subject to change.
 module Servant.API.Routes.Internal.Header
   ( HeaderRep (..)
   , mkHeaderRep
+  , mkHeaderRepOptional
   , GetHeaderReps (..)
   , GetHeaderRep (..)
   )
@@ -36,6 +37,28 @@ mkHeaderRep =
     { _hName = knownSymbolT @sym
     , _hType = typeRep @a
     }
+
+{- | Make the 'TypeRep' in the '_hType' field optional (using 'Maybe'). If the field is already
+optional, leave it as is.
+
+For example:
+
+@
+ghci> mkHeaderRep @"sym" @Int
+HeaderRep {_hName = "sym", _hType = Int}
+
+ghci> mkHeaderRepOptional $ mkHeaderRep @"sym" @Int
+HeaderRep {_hName = "sym", _hType = Maybe Int}
+
+ghci> mkHeaderRepOptional . mkHeaderRepOptional $ mkHeaderRep @"sym" @Int
+HeaderRep {_hName = "sym", _hType = Maybe Int}
+@
+-}
+mkHeaderRepOptional :: HeaderRep -> HeaderRep
+mkHeaderRepOptional h@(HeaderRep _ (App (Con tc) _))
+  | tc == typeRepTyCon (typeRep @Maybe) = h
+mkHeaderRepOptional (HeaderRep name (r :: TypeRep a)) =
+  HeaderRep name $ App (typeRep @Maybe) r
 
 {- | Simple term-level representation of a 'Servant.API.Header.Header'.
 

--- a/servant-routes/src/Servant/API/Routes/Internal/Response.hs
+++ b/servant-routes/src/Servant/API/Routes/Internal/Response.hs
@@ -104,6 +104,11 @@ instance {-# OVERLAPPING #-} (HasResponse a, KnownSymbol desc) => HasResponse (R
       & responseDescription ?~ description
     where
       description = ResponseDescription (knownSymbolT @desc)
+
+instance {-# OVERLAPPING #-} (HasResponse a, GetHeaderReps headers) => HasResponse (WithHeaders headers returnType a) where
+  getResponse =
+    getResponse @a
+      & responseHeaders <>~ Set.fromList (getHeaderReps @headers)
 #endif
 
 {- | Witness that all members of a type-level list are instances of 'HasResponse'.

--- a/servant-routes/test/Servant/API/Routes/HeaderSpec.hs
+++ b/servant-routes/test/Servant/API/Routes/HeaderSpec.hs
@@ -16,6 +16,13 @@ spec = do
     it "should work" $ do
       mkHeaderRep @"sym" @Int `shouldBe` HeaderRep "sym" intTypeRep
 
+  describe "mkHeaderRepOptional" $ do
+    it "should work" $ do
+      mkHeaderRepOptional (mkHeaderRep @"sym" @Int) `shouldBe` mkHeaderRep @"sym" @(Maybe Int)
+    it "should be idempotent" $
+      let h = mkHeaderRepOptional (mkHeaderRep @"sym" @Int)
+      in  mkHeaderRepOptional h `shouldBe` h
+
   describe "GetheaderReps" $ do
     it "should return an empty list for an empty type-level list" $
       getHeaderReps @'[] `shouldBe` []

--- a/servant-routes/test/Servant/API/Routes/HeaderSpec.hs
+++ b/servant-routes/test/Servant/API/Routes/HeaderSpec.hs
@@ -14,7 +14,7 @@ spec :: Spec
 spec = do
   describe "mkHeaderRep" $ do
     it "should work" $ do
-      mkHeaderRep @"sym" @Int `shouldBe` HeaderRep "sym" intTypeRep
+      mkHeaderRep @"sym" @Int `shouldBe` HeaderRep "sym" Nothing intTypeRep
 
   describe "mkHeaderRepOptional" $ do
     it "should work" $ do
@@ -27,7 +27,7 @@ spec = do
     it "should return an empty list for an empty type-level list" $
       getHeaderReps @'[] `shouldBe` []
     it "should recurse properly" $
-      sampleReps `shouldBe` HeaderRep "h1" intTypeRep : getHeaderReps @'[H2, H3]
+      sampleReps `shouldBe` HeaderRep "h1" Nothing intTypeRep : getHeaderReps @'[H2, H3]
 
 type H1 = Header "h1" Int
 

--- a/servant-routes/test/Servant/API/Routes/RequestSpec.hs
+++ b/servant-routes/test/Servant/API/Routes/RequestSpec.hs
@@ -15,7 +15,7 @@ import "this" Servant.API.Routes.SomeSpec hiding (spec)
 {- hlint ignore "Use fold" -}
 
 instance Q.Arbitrary Request where
-  arbitrary = Request <$> genSome (Q.elements [intTypeRep, strTypeRep, unitTypeRep])
+  arbitrary = Request <$> genSome (Q.elements [intSomeTypeRep, strSomeTypeRep, unitSomeTypeRep])
   shrink = unRequest (shrinkSome (const []))
 
 spec :: Spec
@@ -30,6 +30,6 @@ spec = do
     prop "Concatentation" $ do
       \(xs :: [Request]) -> mconcat xs === foldr (<>) mempty xs
   it "AllTypeable" $ do
-    typeReps @'[Int, String] `shouldMatchList` [intTypeRep, strTypeRep]
+    typeReps @'[Int, String] `shouldMatchList` [intSomeTypeRep, strSomeTypeRep]
   describe "Hand-rolled instances" $ do
     testEqInstances @Request

--- a/servant-routes/test/Servant/API/Routes/ResponseSpec.hs
+++ b/servant-routes/test/Servant/API/Routes/ResponseSpec.hs
@@ -26,7 +26,7 @@ instance Q.Arbitrary Responses where
 
 instance Q.Arbitrary Response where
   arbitrary = do
-    _responseType <- Q.elements [intTypeRep, strTypeRep, unitTypeRep]
+    _responseType <- Q.elements [intSomeTypeRep, strSomeTypeRep, unitSomeTypeRep]
     _responseHeaders <- Set.fromList <$> Q.sublistOf sampleReps
     _responseDescription <- Q.liftArbitrary genDescription
     pure Response {..}

--- a/servant-routes/test/Servant/API/Routes/Util.hs
+++ b/servant-routes/test/Servant/API/Routes/Util.hs
@@ -4,15 +4,25 @@ import Data.Typeable
 import qualified Test.Hspec as H
 import qualified Test.Hspec.QuickCheck as H
 import qualified Test.QuickCheck as Q
+import qualified Type.Reflection as R
 
-intTypeRep :: TypeRep
-intTypeRep = typeRep $ Proxy @Int
+intTypeRep :: R.TypeRep Int
+intTypeRep = R.typeRep @Int
 
-strTypeRep :: TypeRep
-strTypeRep = typeRep $ Proxy @String
+intSomeTypeRep :: TypeRep
+intSomeTypeRep = typeRep $ Proxy @Int
 
-unitTypeRep :: TypeRep
-unitTypeRep = typeRep $ Proxy @()
+strTypeRep :: R.TypeRep String
+strTypeRep = R.typeRep @String
+
+strSomeTypeRep :: TypeRep
+strSomeTypeRep = typeRep $ Proxy @String
+
+unitTypeRep :: R.TypeRep ()
+unitTypeRep = R.typeRep @()
+
+unitSomeTypeRep :: TypeRep
+unitSomeTypeRep = typeRep $ Proxy @()
 
 {- HLINT ignore "Use /=" -}
 

--- a/servant-routes/test/Servant/API/Routes/Util.hs
+++ b/servant-routes/test/Servant/API/Routes/Util.hs
@@ -14,7 +14,7 @@ strTypeRep = typeRep $ Proxy @String
 unitTypeRep :: TypeRep
 unitTypeRep = typeRep $ Proxy @()
 
-{- HLINT ignore "Use /= -}
+{- HLINT ignore "Use /=" -}
 
 testEqInstances :: forall a. (Q.Arbitrary a, Show a, Eq a) => H.Spec
 testEqInstances =

--- a/servant-routes/test/Servant/API/RoutesSpec.hs
+++ b/servant-routes/test/Servant/API/RoutesSpec.hs
@@ -283,4 +283,35 @@ spec = do
                                     .~ (intResponse & responses . responseDescription ?~ "int")
                                       <> (strResponse & responses . responseDescription ?~ "string-streaming")
                               ]
+        it "WithHeaders - no headers" $
+          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[] Int Int] Int)
+            `shouldMatchList` [ defRoute "POST"
+                                  & routeResponse .~
+                                      (intResponse & responses . responseHeaders .~ mempty)
+                              ]
+        it "WithHeaders - headers" $
+          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[DescHeader "h1" _ [Int], OptHeader (DescHeader "h2" _ Char)] Int Int] Int)
+            `shouldMatchList` [ defRoute "POST"
+                                  & routeResponse
+                                    .~ ( intResponse
+                                          & responses . responseHeaders
+                                            .~ Set.fromList
+                                              [ mkHeaderRep @"h1" @[Int]
+                                              , mkHeaderRep @"h2" @(Maybe Char)
+                                              ]
+                                       )
+                              ]
+
+        it "WithHeaders - nested OptHeader" $
+          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[OptHeader (DescHeader "h1" _ Char), OptHeader (OptHeader (DescHeader "h2" _ Char))] Int Int] Int)
+            `shouldMatchList` [ defRoute "POST"
+                                  & routeResponse
+                                    .~ ( intResponse
+                                          & responses . responseHeaders
+                                            .~ Set.fromList
+                                              [ mkHeaderRep @"h1" @(Maybe Char)
+                                              , mkHeaderRep @"h2" @(Maybe Char)
+                                              ]
+                                       )
+                              ]
 #endif

--- a/servant-routes/test/Servant/API/RoutesSpec.hs
+++ b/servant-routes/test/Servant/API/RoutesSpec.hs
@@ -16,6 +16,7 @@ import Servant.API
 import Servant.API.MultiVerb
 #endif
 import Servant.API.Routes
+import Servant.API.Routes.Internal.Header
 import Servant.API.Routes.Internal.Response
 import Servant.API.Routes.Response
 import Servant.API.Routes.Route
@@ -290,27 +291,27 @@ spec = do
                                       (intResponse & responses . responseHeaders .~ mempty)
                               ]
         it "WithHeaders - headers" $
-          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[DescHeader "h1" _ [Int], OptHeader (DescHeader "h2" _ Char)] Int Int] Int)
+          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[DescHeader "h1" "h1 - Int" [Int], OptHeader (DescHeader "h2" "h2 - Char" Char)] Int Int] Int)
             `shouldMatchList` [ defRoute "POST"
                                   & routeResponse
                                     .~ ( intResponse
                                           & responses . responseHeaders
                                             .~ Set.fromList
-                                              [ mkHeaderRep @"h1" @[Int]
-                                              , mkHeaderRep @"h2" @(Maybe Char)
+                                              [ (mkHeaderRep @"h1" @[Int]) {_hDescription = Just "h1 - Int"}
+                                              , (mkHeaderRep @"h2" @(Maybe Char)) {_hDescription = Just "h2 - Char"}
                                               ]
                                        )
                               ]
 
         it "WithHeaders - nested OptHeader" $
-          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[OptHeader (DescHeader "h1" _ Char), OptHeader (OptHeader (DescHeader "h2" _ Char))] Int Int] Int)
+          getRoutes @(MultiVerb 'POST '[JSON] '[WithHeaders '[OptHeader (DescHeader "h1" "h1 - Int" Char), OptHeader (OptHeader (DescHeader "h2" "nested" Char))] Int Int] Int)
             `shouldMatchList` [ defRoute "POST"
                                   & routeResponse
                                     .~ ( intResponse
                                           & responses . responseHeaders
                                             .~ Set.fromList
-                                              [ mkHeaderRep @"h1" @(Maybe Char)
-                                              , mkHeaderRep @"h2" @(Maybe Char)
+                                              [ (mkHeaderRep @"h1" @(Maybe Char)) {_hDescription = Just "h1 - Int"}
+                                              , (mkHeaderRep @"h2" @(Maybe Char)) {_hDescription = Just "nested"}
                                               ]
                                        )
                               ]


### PR DESCRIPTION
Follow-up to #42.

As part of #36, we need to rework the internals of `HeaderRep` a bit in order to support `WithHeaders`.

Specifically, we use the `TypeRep` from [Type.Reflection](https://hackage.haskell.org/package/base-4.21.0.0/docs/Type-Reflection.html#t:TypeRep) instead of from [Data.Typeable](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Typeable.html#t:Typeable). We can then implement `GetHeaderRep` (a new smaller class used to provide instances for `GetHeaderReps`) for `DescHeader` and `OptHeader`.

We also add an optional description field to `HeaderRep` to support the `desc` field of `DescHeader`.