### PR TITLE
Support for `Host`

### DIFF
--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.API/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.API/golden
@@ -2,6 +2,7 @@
     "/sub1": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/sub1",
@@ -18,6 +19,7 @@
     "/sub2/x": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/sub2/x",
@@ -40,6 +42,7 @@
     "/sub2/x/y": {
         "PUT": {
             "auths": [],
+            "host": null,
             "method": "PUT",
             "params": [],
             "path": "/sub2/x/y",
@@ -62,6 +65,7 @@
     "/sub3/x2/y1": {
         "PUT": {
             "auths": [],
+            "host": null,
             "method": "PUT",
             "params": [],
             "path": "/sub3/x2/y1",
@@ -84,6 +88,7 @@
     "/sub3/x2/z1": {
         "GET": {
             "auths": [],
+            "host": null,
             "method": "GET",
             "params": [],
             "path": "/sub3/x2/z1",

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.MultiAPI/golden
@@ -2,6 +2,7 @@
     "/multi1": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi1",
@@ -14,6 +15,7 @@
     "/multi2": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi2",
@@ -30,6 +32,7 @@
     "/multi3": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi3",
@@ -46,6 +49,7 @@
     "/multi4": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi4",
@@ -71,6 +75,7 @@
     "/multi5": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi5",
@@ -87,6 +92,7 @@
     "/multi6": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi6",
@@ -114,6 +120,7 @@
     "/multi7": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/multi7",

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI/golden
@@ -2,6 +2,7 @@
     "/": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/",

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI2/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI2/golden
@@ -2,6 +2,7 @@
     "/x": {
         "POST": {
             "auths": [],
+            "host": null,
             "method": "POST",
             "params": [],
             "path": "/x",
@@ -24,6 +25,7 @@
     "/x/y": {
         "PUT": {
             "auths": [],
+            "host": null,
             "method": "PUT",
             "params": [],
             "path": "/x/y",

--- a/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI3/golden
+++ b/servant-routes-golden/.golden/Servant.API.Routes.GoldenSpec.SubAPI3/golden
@@ -2,6 +2,7 @@
     "/x2/y1": {
         "PUT": {
             "auths": [],
+            "host": null,
             "method": "PUT",
             "params": [],
             "path": "/x2/y1",
@@ -24,6 +25,7 @@
     "/x2/z1": {
         "GET": {
             "auths": [],
+            "host": null,
             "method": "GET",
             "params": [],
             "path": "/x2/z1",

--- a/servant-routes/CHANGELOG.md
+++ b/servant-routes/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 ### Added
 
 - `HasRoutes` support for `MultiVerb`. [#44](https://github.com/fpringle/servant-routes/pull/44), [#45](https://github.com/fpringle/servant-routes/pull/45)
+- Support for the `Host` combinator. [#46](https://github.com/fpringle/servant-routes/pull/46)
 
 ### Changed
 

--- a/servant-routes/src/Servant/API/Routes.hs
+++ b/servant-routes/src/Servant/API/Routes.hs
@@ -571,4 +571,7 @@ instance
     where
       method = reflectMethod $ Proxy @method
       response = oneOfResponses @responses
+
+instance (HasRoutes api, KnownSymbol host) => HasRoutes (Host host :> api) where
+  getRoutes = getRoutes @api <&> routeHost %~ (<|> Just (RouteHost (knownSymbolT @host)))
 #endif

--- a/servant-routes/src/Servant/API/Routes/Internal/Route.hs
+++ b/servant-routes/src/Servant/API/Routes/Internal/Route.hs
@@ -13,6 +13,7 @@ module Servant.API.Routes.Internal.Route
     Route (..)
   , ResponseDescription (..)
   , RouteSummary (..)
+  , RouteHost (..)
 
     -- * Optics #optics#
   , routeMethod
@@ -23,6 +24,7 @@ module Servant.API.Routes.Internal.Route
   , routeResponse
   , routeAuths
   , routeSummary
+  , routeHost
   )
 where
 
@@ -49,6 +51,14 @@ newtype RouteSummary = RouteSummary {unSummary :: T.Text}
   deriving (Show)
   deriving (Eq, IsString, Ord, Semigroup, Monoid, ToJSON, FromJSON) via T.Text
 
+{- | Expected host of a route. This will correspond to the Servant @Host@ combinator
+(for `servant>=0.20.3`).
+The behaviour described for 'ResponseDescription' is the same for 'RouteHost'.
+-}
+newtype RouteHost = RouteHost {unHost :: T.Text}
+  deriving (Show)
+  deriving (Eq, IsString, Ord, Semigroup, Monoid, ToJSON, FromJSON) via T.Text
+
 -- | A simple representation of a single endpoint of an API.
 data Route = Route
   { _routeMethod :: Method
@@ -59,6 +69,7 @@ data Route = Route
   , _routeResponse :: Responses
   , _routeAuths :: Set.Set Auth
   , _routeSummary :: Maybe RouteSummary
+  , _routeHost :: Maybe RouteHost
   }
   deriving (Show, Eq)
 
@@ -78,4 +89,5 @@ instance ToJSON Route where
       , "response" .= _routeResponse
       , "auths" .= _routeAuths
       , "summary" .= _routeSummary
+      , "host" .= _routeHost
       ]

--- a/servant-routes/src/Servant/API/Routes/Route.hs
+++ b/servant-routes/src/Servant/API/Routes/Route.hs
@@ -26,11 +26,13 @@ module Servant.API.Routes.Route
   , routeAuths
   , routeDescription
   , routeSummary
+  , routeHost
   , add
 
     -- * Auxiliary types
   , ResponseDescription (..)
   , RouteSummary (..)
+  , RouteHost (..)
   )
 where
 
@@ -59,6 +61,7 @@ defRoute method =
     , _routeResponse = noResponse
     , _routeAuths = mempty
     , _routeSummary = Nothing
+    , _routeHost = Nothing
     }
 
 {- | Pretty-print a 'Route'. Note that the output is minimal and doesn't contain all the information

--- a/servant-routes/test/Servant/API/Routes/RouteSpec.hs
+++ b/servant-routes/test/Servant/API/Routes/RouteSpec.hs
@@ -32,6 +32,7 @@ instance Q.Arbitrary Route where
     _routeResponse <- arbitrary
     _routeAuths <- Set.fromList <$> Q.listOf genAuths
     _routeSummary <- Q.liftArbitrary genSummary
+    _routeHost <- Q.liftArbitrary genHost
 
     pure Route {..}
     where
@@ -41,6 +42,11 @@ instance Q.Arbitrary Route where
           , Custom <$> genAlphaText
           ]
       genSummary = RouteSummary . T.unwords <$> Q.scale (`div` 2) (Q.listOf genAlphaText)
+      genHost =
+        RouteHost <$> do
+          h1 <- genAlphaText
+          h2 <- genAlphaText
+          pure $ h1 <> "." <> h2
 
   shrink r =
     routeMethod shrinkMethod r


### PR DESCRIPTION
Add support for the new [Host](https://hackage-content.haskell.org/package/servant-0.20.3.0/docs/Servant-API-Host.html#t:Host) combinator. Involves a simple newtype and a new field of `Route`.